### PR TITLE
Avoid aliasing bug when compiled with a lot of optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.15)
 set(TARGET_NAME "libnop")
 project(${TARGET_NAME} LANGUAGES CXX)
 

--- a/include/nop/base/enum.h
+++ b/include/nop/base/enum.h
@@ -57,8 +57,14 @@ struct Encoding<T, EnableIfEnum<T>> : EncodingIO<T> {
   template <typename Reader>
   static constexpr Status<void> ReadPayload(EncodingByte prefix, T* value,
                                             Reader* reader) {
-    return Encoding<IntegerType>::ReadPayload(
-        prefix, reinterpret_cast<IntegerType*>(value), reader);
+    IntegerType temp{};
+    auto status =
+        Encoding<IntegerType>::ReadPayload(prefix, &temp, reader);
+    if (!status)
+      return status;
+
+    *value = static_cast<T>(temp);  // avoid strict-aliasing UB
+    return {};
   }
 
  private:


### PR DESCRIPTION
## Purpose
This PR avoids illegal aliasing for enums when compiler optimizations are enabled and compiler decides to takes the liberty of performing the optimizations.

A reproducible example can be found here https://gcc.godbolt.org/z/ssP5PfTxs where ommiting -fno-strict-aliasing showcases the bug (optimization).

It was hit in downstream depthai-core when trying to clean the warning for a potentially uninitialized variable for decoding of std::optional (the commit that reverted the change can be found here https://github.com/luxonis/depthai-core/commit/aae6989529af6342f02e4af13acc01aa237d3353).


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
Include in the `v3.3.0` depthai-core release.

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
The test suite of the project ran without errors + tests on depthai-core will run to see any potential integration errors.